### PR TITLE
Improve authentication token refresh handling

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -3,6 +3,9 @@ module Authentication
 
   included do
     rescue_from JWT::DecodeError, with: :access_denied
+
+    # Make sure we have a valid token before running any action
+    before_action :current_token
   end
 
   private
@@ -22,10 +25,9 @@ module Authentication
   alias_method :authenticate!, :current_token!
 
   # Same as `#current_token!`, but returns nil if user is not authenticated
+  # It will still raise an error if the token is invalid
   def current_token
-    current_token!
-  rescue JWT::DecodeError, ActiveRecord::RecordNotFound
-    nil
+    current_token! if encoded_token
   end
 
   # Return `User` identified by current token. Raises same errors as `#current_token!`

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -22,7 +22,7 @@ function buildUrl ({ url, options }) {
 
 export const doFetch = createFetch({
   options: {
-    async beforeFetch (context) {
+    beforeFetch (context) {
       Object.assign(context, buildUrl(context))
       Object.assign(context, useAuthStore().beforeFetch(context))
       return context

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -38,11 +38,11 @@ export const doFetch = createFetch({
 })
 
 export function useFetch (url, options = {}) {
-  url = buildUrl(url, options.params)
-  const fetch = useAuthStore().handleExpiredToken(doFetch(url, options))
+  const fullUrl = buildUrl(url, options.params)
+  const fetch = useAuthStore().handleExpiredToken(doFetch(fullUrl, options))
 
   // Abort previous fetch when url changes if refetch is enabled
-  watch(url, () => unref(options.refetch) && fetch.abort())
+  watch(fullUrl, () => unref(options.refetch) && fetch.abort())
 
   return fetch
 }

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -18,4 +18,19 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
       headers: create(:access_token, expire_at: 1.second.ago).request_headers
     assert_response 401
   end
+
+  test "home with expired token" do
+    get "/home.json", headers: create(:access_token, expire_at: 1.second.ago).request_headers
+    assert_response 401
+  end
+
+  test "home with invalid token" do
+    get "/home.json", headers: {Authorization: "Bearer invalid"}
+    assert_response 401
+  end
+
+  test "home without a token" do
+    get "/home.json"
+    assert_response 200
+  end
 end


### PR DESCRIPTION
1. On the server, validates the token before any request.
2. On the client, refresh token on any 401 error.
