### PR TITLE
More auth tweaks

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -2,7 +2,7 @@ module Authentication
   extend ActiveSupport::Concern
 
   included do
-    rescue_from JWT::DecodeError, with: :access_denied
+    rescue_from AccessToken::Invalid, JWT::DecodeError, with: :access_denied
 
     # Make sure we have a valid token before running any action
     before_action :current_token

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,4 +1,7 @@
 class AccessToken < ApplicationRecord
+  # Module to tag errors with
+  module Invalid; end
+
   # Signing secret derived from secret_key_base
   class_attribute :secret, default: Rails.application.key_generator.generate_key("access_token")
 
@@ -38,6 +41,10 @@ class AccessToken < ApplicationRecord
 
   def self.validate(token)
     valid.find_by! jti: decode(token).fetch("jti")
+  rescue ActiveRecord::RecordNotFound => e
+    # Tag error to make it rescuable
+    e.extend Invalid
+    raise e
   end
 
   def self.decode(token, verify = true)

--- a/client/src/console.js
+++ b/client/src/console.js
@@ -1,0 +1,18 @@
+// Wrapper around console.log to be able to enable/disable logging
+//
+//   import console from "./console"
+//
+//   console.log("this message will not appear in the console")
+//
+//   // Enable with either of these:
+//   window.debug = true
+//   localStorage.setItem('debug', true)
+//
+//   console.log("This message will appear in the console")
+//
+export default new Proxy(console, {
+  get (target, prop) {
+    const debug = window.debug || localStorage.getItem('debug')
+    return debug ? target[prop] : function () { }
+  }
+})

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -3,6 +3,7 @@ import { useFetch } from '@/client'
 import { useStorage } from '@vueuse/core'
 import { ref, unref, computed, reactive, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
+import console from '@/console'
 
 export default defineStore('auth', () => {
   // Accepting the security trade-offs of persisting in localStorage. There is no other reasonable
@@ -15,18 +16,18 @@ export default defineStore('auth', () => {
   const refreshToken = useStorage('refreshToken', null)
   const isAuthenticated = computed(() => !!user.value.id)
   const ttl = computed(() => {
-    // 60 second jitter to reduce likelihood of multiple tabs refreshing at same time
-    const jitter = Math.round(Math.random() * 60000)
-    return +expireAt.value - new Date() - jitter
+    // 5% random jitter to reduce likelihood of multiple tabs refreshing at same time
+    const jitter = 1 - (Math.random() * 0.05)
+    return (+expireAt.value - new Date()) * jitter
   })
 
   const refreshTimeout = ref(null)
   const refreshPayload = computed(() => ({ refresh_token: refreshToken.value }))
-  const refreshFetch = reactive(useFetch('authenticate', {
+  const refreshFetch = reactive(useFetch('authenticate', { credentials: 'omit' }, {
     immediate: false,
     afterFetch: authenticated,
     onFetchError: reset
-  }, {credentials: 'omit'}).put(refreshPayload).json())
+  }).put(refreshPayload).json())
 
   function signUp (data, useFetchOptions = {}) {
     const fetch = useFetch('users', useFetchOptions).post(data).json()
@@ -53,7 +54,10 @@ export default defineStore('auth', () => {
   }
 
   function refresh () {
-    if (!refreshFetch.isFetching && refreshToken.value) refreshFetch.execute(true)
+    if (!refreshFetch.isFetching && refreshToken.value) {
+      console.log('auth: refreshing token')
+      refreshFetch.execute(true)
+    }
 
     return refreshFetch
   }
@@ -63,6 +67,8 @@ export default defineStore('auth', () => {
     accessToken.value = null
     refreshToken.value = null
     expireAt.value = new Date()
+
+    console.debug('auth: reset')
   }
 
   function authenticated ({ data, response }) {
@@ -70,10 +76,13 @@ export default defineStore('auth', () => {
     expireAt.value = new Date(unref(response).headers.get('expire-at') * 1000)
     refreshToken.value = unref(response).headers.get('refresh-token')
     user.value = unref(data)
+
+    console.debug('auth: authenticated', unref(data))
   }
 
-  function beforeFetch ({ options }) {
+  function beforeFetch ({ url, options }) {
     if (options.credentials !== 'omit' && accessToken.value) {
+      console.debug('auth: adding credentials to request', { url, options, expireAt: expireAt.value })
       options.credentials = 'include'
       options.headers = {
         Authorization: `Bearer ${accessToken.value}`,
@@ -86,7 +95,11 @@ export default defineStore('auth', () => {
 
   function handleExpiredToken (fetch) {
     if (refreshToken.value && fetch.statusCode.value === 401) {
-      refresh().then(fetch.execute)
+      console.warn('auth: token expired, trying to refresh')
+      refresh().then(() => {
+        console.info('auth: token refreshed, retrying', fetch.response.value.url)
+        fetch.execute()
+      })
     }
   }
 
@@ -105,6 +118,10 @@ export default defineStore('auth', () => {
 
   // Schedule refresh when token/ttl changes
   watchEffect(() => {
+    console.debug('auth: setting timeout for refresh', {
+      expireAt: expireAt.value,
+      setTimeout: new Date(+new Date() + ttl.value)
+    })
     clearTimeout(refreshTimeout.value)
     refreshTimeout.value = refreshToken.value && setTimeout(refresh, ttl.value)
   })

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -20,7 +20,12 @@ export default defineStore('auth', () => {
   const refreshFetch = reactive(useFetch('authenticate', { credentials: 'omit' }, {
     immediate: false,
     afterFetch: authenticated,
-    onFetchError: reset
+    onFetchError: ({ error, response }) => {
+      if (response?.status === 401) {
+        console.error('auth: failed to refresh token', error)
+        reset()
+      }
+    }
   }).put(refreshPayload).json())
 
   function signUp (data, useFetchOptions = {}) {

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -24,7 +24,13 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_response 401
   end
 
-  test "home with invalid token" do
+  test "home with invalidated token" do
+    token = create(:access_token, invalidated_at: 1.second.ago)
+    get "/home.json", headers: token.request_headers
+    assert_response 401
+  end
+
+  test "home with bogus token" do
     get "/home.json", headers: {Authorization: "Bearer invalid"}
     assert_response 401
   end


### PR DESCRIPTION
* Return 401 instead of 404 for invalidated token
* Add some logging to auth
* Fix `{ credentials: 'omit' }` in request to `PUT authenticate`
* Refresh token if needed before making another request instead of setTimeout
* Only reset auth after refresh if error status 401