### PR TITLE
Catch AbortError when dismissing share API

### DIFF
--- a/client/src/components/ShareButton.vue
+++ b/client/src/components/ShareButton.vue
@@ -1,7 +1,6 @@
 <script setup>
 import 'share-api-polyfill'
 import { share } from '@/icons'
-import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 
 const props = defineProps({
@@ -16,15 +15,13 @@ const props = defineProps({
 })
 
 const router = useRouter()
-const data = computed(() => {
-  return {
-    title: props.title,
-    url: new URL(router.resolve(props.routerLink).href, window.location).toString()
-  }
-})
 
-function doShare () {
-  return navigator.share(data.value)
+async function doShare () {
+  const data = {
+    url: new URL(router.resolve(props.routerLink).href, window.location).toString(),
+    title: props.title
+  }
+  return navigator.share(data).catch(console.error)
 }
 </script>
 

--- a/client/src/components/ShareItem.vue
+++ b/client/src/components/ShareItem.vue
@@ -22,7 +22,7 @@ function share () {
     url: new URL(router.resolve(props.routerLink).href, window.location).toString()
   }
 
-  return navigator.share(data)
+  return navigator.share(data).catch(console.error)
 }
 </script>
 


### PR DESCRIPTION
The Share API throws an `AbortError` if dismissing the dialog. This catches and logs it in both `ShareItem` and `ShareButton`.

cc @mattgraham