### PR TITLE
Fix error for invalid syntax

### DIFF
--- a/client/src/composables/useChords.js
+++ b/client/src/composables/useChords.js
@@ -1,11 +1,11 @@
 import { Chord } from 'chordsheetjs'
-import { computed } from 'vue'
+import { computed, toValue } from 'vue'
 
 export default function useChords (song) {
   return computed(() => {
     const chords = new Set()
 
-    song.value.lines.forEach(line => {
+    toValue(song)?.lines.forEach(line => {
       line.items.forEach(pair => {
         if (pair.chords) chords.add(pair.chords)
       })

--- a/client/test/composables/useChords.test.js
+++ b/client/test/composables/useChords.test.js
@@ -1,0 +1,26 @@
+import { useChords } from '@/composables'
+import { Chord, ChordProParser } from 'chordsheetjs'
+import { expect, test } from 'vitest'
+import { ref } from 'vue'
+
+test('gracefully fails with null', async () => {
+  expect(useChords(null).value).toEqual([])
+})
+
+test('gracefully fails with null ref', async () => {
+  expect(useChords(ref()).value).toEqual([])
+})
+
+test('returns chords used in the song', () => {
+  const song = new ChordProParser().parse('{title: Hello}\n[C]Hello [G]world [D]!')
+  expect(useChords(song).value).toEqual(['C', 'G', 'D'].map(name => Chord.parse(name)))
+})
+
+test('works with song ref', () => {
+  const song = ref(new ChordProParser().parse('{title: Hello}\n[C]Hello [G]world [D]!'))
+  const chords = useChords(song)
+
+  expect(chords.value).toEqual(['C', 'G', 'D'].map(name => Chord.parse(name)))
+  song.value = new ChordProParser().parse('{title: Hello}\n[F]Hello [C]world [B]!')
+  expect(chords.value).toEqual(['F', 'C', 'B'].map(name => Chord.parse(name)))
+})


### PR DESCRIPTION
This fixes an issue that was preventing an error from being shown when a chordsheet has invalid syntax. It's not the most helpful error page, but it's better than a blank page!

<img width="1457" alt="image" src="https://github.com/chordbook/chordbook/assets/173/0cd419ef-77aa-4e62-82b9-7d1d464a46fc">


@mattgraham