### PR TITLE
Refactor data-source to automatically handle pagination

### DIFF
--- a/client/src/components/AddToSetlistModal.vue
+++ b/client/src/components/AddToSetlistModal.vue
@@ -63,7 +63,6 @@ async function newModal () {
           <data-source
             v-slot="{ items }"
             src="setlists"
-            paginate
           >
             <ion-list>
               <setlist-item

--- a/client/src/components/DataSource.vue
+++ b/client/src/components/DataSource.vue
@@ -87,8 +87,6 @@ await load()
 
   <ion-infinite-scroll
     v-if="pager.isPaginating"
-    :disabled="pager.isFetching || !pager.isPaginating"
-    threshold="500px"
     @ion-infinite="load().then(() => $event.target.complete())"
   >
     <ion-infinite-scroll-content

--- a/client/src/components/DataSource.vue
+++ b/client/src/components/DataSource.vue
@@ -46,10 +46,6 @@ const props = defineProps({
   options: {
     type: Object,
     default () { return {} }
-  },
-  paginate: {
-    type: Boolean,
-    default: true
   }
 })
 
@@ -90,7 +86,7 @@ await load()
   </template>
 
   <ion-infinite-scroll
-    v-if="paginate"
+    v-if="pager.isPaginating"
     :disabled="pager.isFetching || !pager.isPaginating"
     threshold="500px"
     @ion-infinite="load().then(() => $event.target.complete())"

--- a/client/src/components/SongsheetVersionsModal.vue
+++ b/client/src/components/SongsheetVersionsModal.vue
@@ -39,7 +39,6 @@ defineProps({
           <data-source
             v-slot="{ items }"
             :src="`tracks/${id}/songsheets`"
-            paginate
           >
             <template
               v-for="version in items"

--- a/client/src/composables/usePaginatedFetch.js
+++ b/client/src/composables/usePaginatedFetch.js
@@ -39,7 +39,6 @@ export default function usePaginatedFetch (url, fetchOptions = {}) {
       } else {
         nextUrl.value = null
       }
-      // emit('load', page)
     })
 
     pages.push(page)

--- a/client/src/composables/usePaginatedFetch.js
+++ b/client/src/composables/usePaginatedFetch.js
@@ -11,7 +11,7 @@ export default function usePaginatedFetch (url, fetchOptions = {}) {
     const page = pages[0]
     return page?.isFinished && !page.error && page.data.length === 0
   })
-  const isPaginating = computed(() => !!nextUrl.value)
+  const isPaginating = ref(false)
 
   // Load the next page
   function load (reload = false) {
@@ -36,8 +36,10 @@ export default function usePaginatedFetch (url, fetchOptions = {}) {
       const links = LinkHeader.parse(page.response.value.headers.get('Link') ?? '')
       if (links.has('rel', 'next')) {
         nextUrl.value = links.get('rel', 'next')[0].uri
+        isPaginating.value = true
       } else {
         nextUrl.value = null
+        isPaginating.value = false
       }
     })
 

--- a/client/src/views/ArtistListView.vue
+++ b/client/src/views/ArtistListView.vue
@@ -33,7 +33,6 @@ import LibraryPlaceholder from '@/components/LibraryPlaceholder.vue'
       <data-source
         :src="$route.path"
         :params="$route.query"
-        paginate
       >
         <template #empty>
           <library-placeholder type="artist" />

--- a/client/src/views/GenreListView.vue
+++ b/client/src/views/GenreListView.vue
@@ -3,7 +3,6 @@
     <ion-list-header>Browse by Genre</ion-list-header>
     <data-source
       src="genres"
-      paginate
     >
       <template #page="{ data }">
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 ion-margin">

--- a/client/src/views/SetlistDetailView.vue
+++ b/client/src/views/SetlistDetailView.vue
@@ -228,7 +228,6 @@ async function destroy () {
               ref="songsheets"
               v-slot="{ items }"
               :src="`setlists/${props.id}/songsheets`"
-              paginate
             >
               <ion-item-sliding
                 v-for="songsheet in items"

--- a/client/src/views/SetlistListView.vue
+++ b/client/src/views/SetlistListView.vue
@@ -43,7 +43,6 @@ import SetlistCard from '@/components/SetlistCard.vue'
         v-slot="{ items }"
         src="setlists"
         :params="$route.query"
-        paginate
       >
         <ion-list>
           <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">

--- a/client/src/views/SongsheetListView.vue
+++ b/client/src/views/SongsheetListView.vue
@@ -57,7 +57,6 @@ import { add } from 'ionicons/icons'
         ref="dataSource"
         :src="$route.path"
         :params="$route.query"
-        paginate
       >
         <template #empty>
           <library-placeholder type="song" />

--- a/client/src/views/TrackListView.vue
+++ b/client/src/views/TrackListView.vue
@@ -23,7 +23,6 @@
         v-slot="{ items }"
         :src="$route.path"
         :params="$route.query"
-        paginate
       >
         <ion-list>
           <track-item

--- a/client/src/views/TrackView.vue
+++ b/client/src/views/TrackView.vue
@@ -41,7 +41,6 @@ function loaded ({ data }) {
         <data-source
           v-slot="{ items }"
           :src="`tracks/${id}/songsheets`"
-          paginate
           @load="loaded"
         >
           <songsheet-item


### PR DESCRIPTION
Small tweak to remove `paginate` prop from `<data-source>` component. Pagination is automatically turned on if API returns a paginated response.