### PR TITLE
Integrate MusixMatch for lyrics permissions

### DIFF
--- a/app/jobs/musix_match/get_lyrics.rb
+++ b/app/jobs/musix_match/get_lyrics.rb
@@ -2,6 +2,8 @@ class MusixMatch::GetLyrics < ApplicationJob
   queue_as :low
 
   def perform(reference)
+    return unless Flipper.enabled?(:musixmatch)
+
     response = MusixMatch.track_lyrics(reference.identifier)
     reference.update!(data: response["message"]["body"]["lyrics"])
   end

--- a/app/jobs/musix_match/get_lyrics.rb
+++ b/app/jobs/musix_match/get_lyrics.rb
@@ -1,0 +1,8 @@
+class MusixMatch::GetLyrics < ApplicationJob
+  queue_as :low
+
+  def perform(reference)
+    response = MusixMatch.track_lyrics(reference.identifier)
+    reference.update!(data: response["message"]["body"]["lyrics"])
+  end
+end

--- a/app/jobs/musix_match/match_track_job.rb
+++ b/app/jobs/musix_match/match_track_job.rb
@@ -1,0 +1,11 @@
+class MusixMatch::MatchTrackJob < ApplicationJob
+  queue_as :low
+
+  def perform(track)
+    response = MusixMatch.match_track(q_artist: track.artist.name, q_track: track.title, q_album: track.album.title)
+    data = response["message"]["body"]["track"]
+    reference = track.references.find_or_initialize_by(source: :musixmatch, identifier: data["track_id"])
+    reference.update! data: data
+    MusixMatch::GetLyrics.perform_later(reference)
+  end
+end

--- a/app/jobs/musix_match/match_track_job.rb
+++ b/app/jobs/musix_match/match_track_job.rb
@@ -2,6 +2,8 @@ class MusixMatch::MatchTrackJob < ApplicationJob
   queue_as :low
 
   def perform(track)
+    return unless Flipper.enabled?(:musixmatch)
+
     response = MusixMatch.match_track(q_artist: track.artist.name, q_track: track.title, q_album: track.album.title)
     data = response["message"]["body"]["track"]
     reference = track.references.find_or_initialize_by(source: :musixmatch, identifier: data["track_id"])

--- a/app/models/concerns/referenceable.rb
+++ b/app/models/concerns/referenceable.rb
@@ -1,0 +1,7 @@
+module Referenceable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :references, as: :record, dependent: :destroy
+  end
+end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,0 +1,12 @@
+class Reference < ApplicationRecord
+  belongs_to :record, polymorphic: true
+  enum :source, musixmatch: "musixmatch"
+
+  def data=(new_data)
+    write_attribute :data, data.merge(new_data)
+  end
+
+  def data
+    (read_attribute(:data) || {}).with_indifferent_access
+  end
+end

--- a/app/models/songsheet.rb
+++ b/app/models/songsheet.rb
@@ -38,6 +38,18 @@ class Songsheet < ApplicationRecord
 
   searchkick word_start: [:title, :everything], stem: false, callbacks: :async
 
+  def copyright
+    reference = track&.references&.musixmatch&.first
+    return unless reference
+
+    {
+      notice: reference.data["lyrics_copyright"],
+      url: reference.data["track_share_url"],
+      script_url: reference.data["script_tracking_url"],
+      pixel_url: reference.data["pixel_tracking_url"]
+    }
+  end
+
   def search_data
     {
       type: self.class,

--- a/app/views/api/songsheets/show.json.jbuilder
+++ b/app/views/api/songsheets/show.json.jbuilder
@@ -4,3 +4,5 @@ json.media @songsheet.all_media
 json.artists do
   json.array! @songsheet.artists, partial: "api/artists/artist", as: :artist
 end
+
+json.extract! @songsheet, :copyright if Flipper.enabled?(:musixmatch)

--- a/client/src/components/Songsheet.vue
+++ b/client/src/components/Songsheet.vue
@@ -67,6 +67,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  copyright: {
+    type: [Object, null],
+    default: null,
+  },
 });
 
 const parser = reactive(useSongsheetParser(toRef(props, "source")));
@@ -251,11 +255,9 @@ watch(
         </template>
       </songsheet-content>
 
-      <div
-        class="snap-end text-xs text-muted mb-8 flex flex-col md:flex-row gap-2"
-      >
+      <div class="snap-end text-xs text-muted mb-8 flex flex-col gap-1">
         <div>Updated {{ formatDate(updated_at) }}</div>
-        <div v-if="imported_from" class="md:ms-auto">
+        <div v-if="imported_from">
           Imported from
           <a
             target="_blank"
@@ -264,6 +266,12 @@ watch(
           >
             {{ hostname(imported_from) }}
           </a>
+        </div>
+        <div v-if="copyright">
+          <a :href="copyright.url" rel="nofollow" class="text-xs text-muted">{{
+            copyright.notice
+          }}</a>
+          <img :src="copyright.pixel_url" />
         </div>
       </div>
     </column-layout>

--- a/client/src/views/DiscoverView.vue
+++ b/client/src/views/DiscoverView.vue
@@ -4,7 +4,7 @@ import ModelAvatar from "@/components/ModelAvatar.vue";
 import { useRouteQuery } from "@vueuse/router";
 import { ref, reactive } from "vue";
 import { getMode } from "@ionic/core";
-import { useFetch } from "@/client"
+import { useFetch } from "@/client";
 
 const types = {
   All: "",

--- a/db/migrate/20240503175432_create_references.rb
+++ b/db/migrate/20240503175432_create_references.rb
@@ -1,0 +1,14 @@
+class CreateReferences < ActiveRecord::Migration[7.1]
+  def change
+    create_table :references, id: :uuid do |t|
+      t.references :record, polymorphic: true, null: false, type: :uuid
+      t.string :identifier
+      t.string :source
+      t.json :data
+
+      t.timestamps
+
+      t.index [:record_type, :record_id, :source], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -496,6 +496,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_174643) do
     t.index ["user_id"], name: "index_searchjoy_searches_on_user_id"
   end
 
+  create_table "references", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "record_type", null: false
+    t.uuid "record_id", null: false
+    t.string "identifier"
+    t.string "source"
+    t.json "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id"], name: "index_references_on_record"
+  end
+
   create_table "setlist_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "position"
     t.datetime "created_at", null: false

--- a/lib/musix_match.rb
+++ b/lib/musix_match.rb
@@ -1,0 +1,24 @@
+module MusixMatch
+  extend self
+  include HTTParty
+
+  API_KEY = ENV["MUSIXMATCH_API_KEY"] || "test"
+
+  base_uri "https://api.musixmatch.com"
+  raise_on 400..600
+  default_params apikey: API_KEY
+  logger Rails.logger
+  format :json
+
+  def match_track(params = {})
+    get "/ws/1.1/matcher.track.get", query: params
+  end
+
+  def track_lyrics(track_id)
+    get "/ws/1.1/track.lyrics.get", query: {track_id: track_id}
+  end
+
+  def artist_search(params = {})
+    get "/ws/1.1/artist.search", query: params
+  end
+end

--- a/test/controllers/api/songsheets_controller_test.rb
+++ b/test/controllers/api/songsheets_controller_test.rb
@@ -51,6 +51,18 @@ class Api::SongsheetsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show with copyright tracking" do
+    Flipper.enable :musixmatch
+    reference = create :reference, :musixmatch
+    @songsheet.update! track: reference.record
+    get api_songsheet_url(@songsheet, format: :json)
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_match(/MusixMatch/, body["copyright"]["notice"])
+    assert_match(/musixmatch.com/, body["copyright"]["script_url"])
+    assert_match(/musixmatch.com/, body["copyright"]["pixel_url"])
+  end
+
   test "create unauthenticated" do
     post api_songsheets_url
     assert_response :unauthorized

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -74,4 +74,21 @@ FactoryBot.define do
       properties { {id: record.id, type: record.model_name.name} }
     end
   end
+
+  factory :reference do
+    record { build(:track) }
+
+    trait :musixmatch do
+      source { "musixmatch" }
+      identifier { "mm-#{record.id}" }
+
+      data do
+        {
+          "lyrics_copyright" => "© 2021 MusixMatch",
+          "script_tracking_url" => "https://www.musixmatch.com/track/123",
+          "pixel_tracking_url" => "https://www.musixmatch.com/track/123/pixel"
+        }
+      end
+    end
+  end
 end

--- a/test/jobs/musix_match/get_lyrics_test.rb
+++ b/test/jobs/musix_match/get_lyrics_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class MusixMatch::MatchTrackJobTest < ActiveJob::TestCase
+  test "updates reference with lyrics" do
+    reference = Reference.create! record: create(:track), source: :musixmatch, identifier: 277941381, data: {"track_rating" => 57}
+    VCR.use_cassette("musixmatch/track.lyrics.get") do
+      MusixMatch::GetLyrics.perform_now(reference)
+      assert_equal "When I find myself in times of trouble", reference.reload.data["lyrics_body"].split("\n").first
+      assert_equal 57, reference.data["track_rating"]
+    end
+  end
+end

--- a/test/jobs/musix_match/get_lyrics_test.rb
+++ b/test/jobs/musix_match/get_lyrics_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class MusixMatch::MatchTrackJobTest < ActiveJob::TestCase
+  setup do
+    Flipper.enable :musixmatch
+  end
+
   test "updates reference with lyrics" do
     reference = Reference.create! record: create(:track), source: :musixmatch, identifier: 277941381, data: {"track_rating" => 57}
     VCR.use_cassette("musixmatch/track.lyrics.get") do

--- a/test/jobs/musix_match/match_track_job_test.rb
+++ b/test/jobs/musix_match/match_track_job_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class MusixMatch::MatchTrackJobTest < ActiveJob::TestCase
+  test "saves reference to matched track" do
+    artist = create :artist, name: "The Beatles"
+    album = create :album, title: "Let It Be", artist: artist
+    track = create :track, title: "Let It Be", album: album, artist: artist
+
+    assert_difference -> { track.references.count } do
+      # should not duplicate on second run
+      2.times do
+        VCR.use_cassette("musixmatch/matcher.track.get") do
+          MusixMatch::MatchTrackJob.new.perform(track)
+        end
+      end
+    end
+
+    reference = track.references.last
+    assert_equal "musixmatch", reference.source
+    assert_equal "277941381", reference.identifier
+    assert_equal 57, reference.data["track_rating"]
+  end
+end

--- a/test/jobs/musix_match/match_track_job_test.rb
+++ b/test/jobs/musix_match/match_track_job_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class MusixMatch::MatchTrackJobTest < ActiveJob::TestCase
+  setup do
+    Flipper.enable :musixmatch
+  end
+
   test "saves reference to matched track" do
     artist = create :artist, name: "The Beatles"
     album = create :album, title: "Let It Be", artist: artist

--- a/test/models/reference_test.rb
+++ b/test/models/reference_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class ReferenceTest < ActiveSupport::TestCase
+  test "data= merges values" do
+    reference = Reference.new(data: {a: 1, b: 2})
+    reference.data = {"b" => 2, :c => 3}
+    assert_equal({a: 1, b: 2, c: 3}.with_indifferent_access, reference.data)
+  end
+end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -30,4 +30,9 @@ class TrackTest < ActiveSupport::TestCase
 
     assert_equal album.genre, track.genre
   end
+
+  test "musixmatch lookup" do
+    assert_no_enqueued_jobs { create :track, songsheets_count: 0 }
+    assert_enqueued_with(job: MusixMatch::MatchTrackJob) { create :track, songsheets_count: 1 }
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ end
 
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
+  include ActiveJob::TestHelper
 
   # Run tests in parallel with specified workers
   # parallelize(workers: :number_of_processors, with: :threads)
@@ -49,5 +50,6 @@ VCR.configure do |config|
   config.default_cassette_options = {record: ENV["VCR"] ? ENV["VCR"].to_sym : :once}
 
   config.filter_sensitive_data("<APIKEY>") { LookupMetadata::API_KEY }
+  config.filter_sensitive_data("<MUSIXMATCH-API-KEY>") { MusixMatch::API_KEY }
   config.filter_sensitive_data("<YOUTUBE-API-KEY>") { YoutubeLookup::API_KEY }
 end

--- a/test/unit/musix_match_test.rb
+++ b/test/unit/musix_match_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class MusixMatchTest < ActiveSupport::TestCase
+  test "match_track" do
+    VCR.use_cassette("musixmatch/matcher.track.get") do
+      result = MusixMatch.match_track(q_artist: "The Beatles", q_track: "Let It Be", q_album: "Let It Be")
+      assert_equal 277941381, result["message"]["body"]["track"]["track_id"]
+    end
+  end
+end

--- a/test/vcr/musixmatch/artist_search.yml
+++ b/test/vcr/musixmatch/artist_search.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.musixmatch.com/ws/1.1/artist.search?apikey=<MUSIXMATCH-API-KEY>&f_artist_mbid=b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1084"
+        Content-Type:
+          - text/plain; charset=utf-8
+        Server:
+          - nginx
+        Via:
+          - 1.1 varnish, 1.1 varnish
+        X-Mxm-Header-Execute-Time:
+          - "0.055521965026855"
+        X-Mxm-Header-Status:
+          - "200"
+        X-Restarts:
+          - "0"
+        X-Varnish-Instance:
+          - api
+        Accept-Ranges:
+          - bytes
+        Age:
+          - "0"
+        Date:
+          - Fri, 03 May 2024 17:01:57 GMT
+        X-Served-By:
+          - cache-pdk-kpdk1780120-PDK
+        X-Cache:
+          - MISS
+        X-Cache-Hits:
+          - "0"
+        X-Timer:
+          - S1714755717.052092,VS0,VE90
+        Vary:
+          - Accept-Encoding
+      body:
+        encoding: ASCII-8BIT
+        string:
+          '{"message":{"header":{"status_code":200,"execute_time":0.055521965026855,"available":1},"body":{"artist_list":[{"artist":{"artist_id":160,"artist_name":"The
+          Beatles","artist_name_translation_list":[{"artist_name_translation":{"language":"JA","translation":"\u30d3\u30fc\u30c8\u30eb\u30ba"}}],"artist_comment":"","artist_country":"GB","artist_alias_list":[{"artist_alias":"\u30d3\u30fc\u30c8\u30eb\u30ba"},{"artist_alias":"Pitousiyuedui"},{"artist_alias":"\u0411\u0438\u0442\u043b\u0437"},{"artist_alias":"\u30b6\u30fb\u30d3\u30fc\u30c8\u30eb\u30ba"},{"artist_alias":"\ub354
+          \ube44\ud2c0\uc988"},{"artist_alias":"Los Beatles"},{"artist_alias":"Beatles"},{"artist_alias":"fab
+          four"},{"artist_alias":"Beetles"},{"artist_alias":"\u62ab\u5934\u58eb"},{"artist_alias":"\u62ab\u982d\u56db"},{"artist_alias":"The
+          Beatles"}],"artist_rating":87,"artist_twitter_url":"https:\/\/twitter.com\/thebeatles","artist_credits":{"artist_list":[]},"restricted":0,"updated_time":"2021-10-13T07:05:58Z","begin_date_year":"1957","begin_date":"1957-03-00","end_date_year":"1970","end_date":"1970-04-10"}}]}}}'
+    recorded_at: Fri, 03 May 2024 17:01:57 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr/musixmatch/matcher_track_get.yml
+++ b/test/vcr/musixmatch/matcher_track_get.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.musixmatch.com/ws/1.1/matcher.track.get?apikey=<MUSIXMATCH-API-KEY>&q_album=Let%20It%20Be&q_artist=The%20Beatles&q_track=Let%20It%20Be
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1005"
+        Content-Type:
+          - text/plain; charset=utf-8
+        Server:
+          - nginx
+        Via:
+          - 1.1 varnish, 1.1 varnish
+        X-Mxm-Header-Execute-Time:
+          - "0.16777205467224"
+        X-Mxm-Header-Status:
+          - "200"
+        X-Restarts:
+          - "0"
+        X-Varnish-Instance:
+          - api
+        Accept-Ranges:
+          - bytes
+        Age:
+          - "0"
+        Date:
+          - Fri, 03 May 2024 17:26:20 GMT
+        X-Served-By:
+          - cache-pdk-kpdk1780107-PDK
+        X-Cache:
+          - MISS
+        X-Cache-Hits:
+          - "0"
+        X-Timer:
+          - S1714757180.953895,VS0,VE205
+        Vary:
+          - Accept-Encoding
+      body:
+        encoding: ASCII-8BIT
+        string:
+          '{"message":{"header":{"status_code":200,"execute_time":0.16777205467224,"confidence":1000,"mode":"search","cached":0},"body":{"track":{"track_id":277941381,"track_name":"Let
+          It Be","track_name_translation_list":[],"track_rating":57,"commontrack_id":168735284,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":1,"num_favourite":18,"album_id":62678941,"album_name":"Let
+          It Be","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-5?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-5\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-01-20T08:09:16Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1146,"music_genre_parent_id":21,"music_genre_name":"Arena
+          Rock","music_genre_name_extended":"Rock \/ Arena Rock","music_genre_vanity":"Rock-Arena-Rock"}}]}}}}}'
+    recorded_at: Fri, 03 May 2024 17:26:20 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr/musixmatch/track_lyrics_get.yml
+++ b/test/vcr/musixmatch/track_lyrics_get.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.musixmatch.com/ws/1.1/track.lyrics.get?apikey=<MUSIXMATCH-API-KEY>&track_id=277941381
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1861"
+        Content-Type:
+          - text/plain; charset=utf-8
+        Server:
+          - nginx
+        Via:
+          - 1.1 varnish, 1.1 varnish
+        X-Mxm-Header-Execute-Time:
+          - "0.015895128250122"
+        X-Mxm-Header-Status:
+          - "200"
+        X-Restarts:
+          - "0"
+        X-Varnish-Instance:
+          - api
+        Accept-Ranges:
+          - bytes
+        Age:
+          - "0"
+        Date:
+          - Thu, 23 May 2024 14:18:02 GMT
+        X-Served-By:
+          - cache-mia-kmia1760077-MIA
+        X-Cache:
+          - MISS
+        X-Cache-Hits:
+          - "0"
+        X-Timer:
+          - S1716473883.795027,VS0,VE72
+        Vary:
+          - Accept-Encoding
+      body:
+        encoding: ASCII-8BIT
+        string:
+          '{"message":{"header":{"status_code":200,"execute_time":0.015895128250122},"body":{"lyrics":{"lyrics_id":34207630,"explicit":0,"lyrics_body":"When
+          I find myself in times of trouble\nMother Mary comes to me\nSpeaking words
+          of wisdom, let it be\n\nAnd in my hour of darkness\nShe is standing right
+          in front of me\nSpeaking words of wisdom, let it be\n\nLet it be, let it be\nLet
+          it be, let it be\nWhisper words of wisdom, let it be\n\nAnd when the broken-hearted
+          people\nLiving in the world agree\nThere will be an answer, let it be\n\nFor
+          though they may be parted\n...\n\n******* This Lyrics is NOT for Commercial
+          use *******","script_tracking_url":"https:\/\/tracking.musixmatch.com\/t1.0\/m_js\/e_1\/sn_0\/l_34207630\/su_0\/rs_0\/tr_3vUCAHhFpeIq7JHhnNbhLT4vkve5EBMqoupndiGSsG9OFCp951hCxfZWqM05BKIK8KoHDByAKzag3N65VF2R2XrWhlxBuPtb1_acIhm6V4zvjNCGS8XNeRua3pSQao9KQp4Jq8sK9fVqSlECXkCAuacOYBxKSwmKQCWPJBj7vEoucx36uo36rQnhADsIookBLq6LfgZ8-B4OSmOq6XmUzNCNqiCPrtDjbjWYAXle9lJVbQclk9OPpJ1SdFyFwfRT4af-6WTc37HDRPLvdXdP1GC_7w7cG2vXVgvbWwakbHi_hpyqVW0YR4V3o1ew9k4e7ZZUxsSy0ij8QxOB2remwzHNxI7JRZ8E6jjXqH5263M2JDPZXwauYxDaxEqcDXREEWIltYFR0xkoOU7ImjL8vkOdWPwZTgaG\/","pixel_tracking_url":"https:\/\/tracking.musixmatch.com\/t1.0\/m_img\/e_1\/sn_0\/l_34207630\/su_0\/rs_0\/tr_3vUCAJ8wBMQ_KhGLD47lYaDjl4O4nR7dDHm_Jn016pSjxdokaNnMKGnZkdR-hJMzLaqbOSGbpoa5Z_NdlRb1SttVvBEDGNf-iddZvM-1SUqfUfeUobpSTeQ1QIlAzO8NjUEkY2_ZnI5iyD_8T8vRrJo0bNwkivWq13BqFzzeNJfY58Juv1hwOXlLSa73KpSdGWUbM_gnD1G9Lp-PX2V-72C_V-jGb0c24i_fjyT76UO01GSTd-C0pqW5GOH9_bLEAibb5ngRUr0_SnnmMHAmlGnFEGW9zENsze00Zo_Iory_uscN_tz21ZHZKec8M0RJfuIKMnnNNQ-n2AGQWuevUDFx41qSnFQ8xNtilOQcn-Q3aGfzX7-6W-eg7wOAWTxtvgO2kVrcoqdY6b4l9V1LMyLyxzetnllj\/","lyrics_copyright":"Lyrics
+          powered by www.musixmatch.com. This Lyrics is NOT for Commercial use and only
+          30% of the lyrics are returned.","updated_time":"2024-01-20T08:09:15Z"}}}}'
+    recorded_at: Thu, 23 May 2024 14:18:02 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr/musixmatch/track_search.yml
+++ b/test/vcr/musixmatch/track_search.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://api.musixmatch.com/ws/1.1/track.search?apikey=<MUSIXMATCH-API-KEY>&f_artist_id=160&q_track=Let%20It%20Be&s_track_rating=desc
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "10075"
+        Content-Type:
+          - text/plain; charset=utf-8
+        Server:
+          - nginx
+        Via:
+          - 1.1 varnish, 1.1 varnish
+        X-Mxm-Header-Execute-Time:
+          - "0.033776998519897"
+        X-Mxm-Header-Status:
+          - "200"
+        X-Restarts:
+          - "0"
+        X-Varnish-Instance:
+          - api
+        Accept-Ranges:
+          - bytes
+        Age:
+          - "0"
+        Date:
+          - Fri, 03 May 2024 17:07:00 GMT
+        X-Served-By:
+          - cache-pdk-kpdk1780116-PDK
+        X-Cache:
+          - MISS
+        X-Cache-Hits:
+          - "0"
+        X-Timer:
+          - S1714756020.091590,VS0,VE69
+        Vary:
+          - Accept-Encoding
+      body:
+        encoding: ASCII-8BIT
+        string:
+          '{"message":{"header":{"status_code":200,"execute_time":0.033776998519897,"available":14},"body":{"track_list":[{"track":{"track_id":89179233,"track_name":"Let
+          It Be","track_name_translation_list":[{"track_name_translation":{"language":"u0","translation":"Let
+          It Be"}}],"track_rating":71,"commontrack_id":47341444,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":1,"num_favourite":5085,"album_id":21196056,"album_name":"The
+          Beatles 1967-1970 (The Blue Album)","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Remastered-2009?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Remastered-2009\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2023-07-06T12:18:37Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":14,"music_genre_parent_id":34,"music_genre_name":"Pop","music_genre_name_extended":"Pop","music_genre_vanity":"Pop"}},{"music_genre":{"music_genre_id":21,"music_genre_parent_id":34,"music_genre_name":"Rock","music_genre_name_extended":"Rock","music_genre_vanity":"Rock"}},{"music_genre":{"music_genre_id":1101,"music_genre_parent_id":22,"music_genre_name":"Gospel","music_genre_name_extended":"Christian
+          & Gospel \/ Gospel","music_genre_vanity":"Christian-Gospel-Gospel"}}]}}},{"track":{"track_id":87843090,"track_name":"Let
+          It Be","track_name_translation_list":[],"track_rating":71,"commontrack_id":69568,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":1,"num_favourite":4218,"album_id":21121586,"album_name":"1","artist_id":160,"artist_name":"The
+          Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Remastered-2015?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Remastered-2015\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-03-02T12:09:24Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1133,"music_genre_parent_id":14,"music_genre_name":"Pop\/Rock","music_genre_name_extended":"Pop
+          \/ Pop\/Rock","music_genre_vanity":"Pop-Pop-Rock"}},{"music_genre":{"music_genre_id":21,"music_genre_parent_id":34,"music_genre_name":"Rock","music_genre_name_extended":"Rock","music_genre_vanity":"Rock"}}]}}},{"track":{"track_id":277941381,"track_name":"Let
+          It Be","track_name_translation_list":[],"track_rating":57,"commontrack_id":168735284,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":1,"num_favourite":18,"album_id":62678941,"album_name":"Let
+          It Be","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-5?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-5\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-01-20T08:09:16Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1146,"music_genre_parent_id":21,"music_genre_name":"Arena
+          Rock","music_genre_name_extended":"Rock \/ Arena Rock","music_genre_vanity":"Rock-Arena-Rock"}}]}}},{"track":{"track_id":89179034,"track_name":"Let
+          It Be - Remastered 2009","track_name_translation_list":[],"track_rating":79,"commontrack_id":136657545,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":1,"num_favourite":41,"album_id":21196039,"album_name":"Let
+          It Be (Remastered)","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-1?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-1\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-03-02T12:24:54Z","primary_genres":{"music_genre_list":[]}}},{"track":{"track_id":222827300,"track_name":"Let
+          It Be - 2021 Mix","track_name_translation_list":[],"track_rating":72,"commontrack_id":132596344,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":1,"num_favourite":9,"album_id":46744542,"album_name":"Let
+          It Be (Super Deluxe)","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-2021-Mix?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-2021-Mix\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-03-24T18:24:11Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1134,"music_genre_parent_id":14,"music_genre_name":"Soft
+          Rock","music_genre_name_extended":"Pop \/ Soft Rock","music_genre_vanity":"Pop-Soft-Rock"}},{"music_genre":{"music_genre_id":1146,"music_genre_parent_id":21,"music_genre_name":"Arena
+          Rock","music_genre_name_extended":"Rock \/ Arena Rock","music_genre_vanity":"Rock-Arena-Rock"}}]}}},{"track":{"track_id":222827344,"track_name":"Let
+          It Be - Take 28","track_name_translation_list":[],"track_rating":71,"commontrack_id":134402958,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":0,"num_favourite":3,"album_id":46744542,"album_name":"Let
+          It Be (Super Deluxe)","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Take-28?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Take-28\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-03-24T18:24:31Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1146,"music_genre_parent_id":21,"music_genre_name":"Arena
+          Rock","music_genre_name_extended":"Rock \/ Arena Rock","music_genre_vanity":"Rock-Arena-Rock"}}]}}},{"track":{"track_id":152706776,"track_name":"Let
+          It Be - Naked Version \/ Remastered 2013","track_name_translation_list":[],"track_rating":57,"commontrack_id":85044189,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":1,"num_favourite":3,"album_id":29275061,"album_name":"Let
+          It Be... Naked (Remastered)","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/let-it-be-4?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/let-it-be-4\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-03-24T18:24:52Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1146,"music_genre_parent_id":21,"music_genre_name":"Arena
+          Rock","music_genre_name_extended":"Rock \/ Arena Rock","music_genre_vanity":"Rock-Arena-Rock"}},{"music_genre":{"music_genre_id":21,"music_genre_parent_id":34,"music_genre_name":"Rock","music_genre_name_extended":"Rock","music_genre_vanity":"Rock"}}]}}},{"track":{"track_id":222827367,"track_name":"Let
+          It Be - Single Version \/ 2021 Mix","track_name_translation_list":[],"track_rating":57,"commontrack_id":134402975,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":0,"num_favourite":2,"album_id":46744542,"album_name":"Let
+          It Be (Super Deluxe)","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Single-Version-2021-Mix?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Single-Version-2021-Mix\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-04-15T10:10:03Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1146,"music_genre_parent_id":21,"music_genre_name":"Arena
+          Rock","music_genre_name_extended":"Rock \/ Arena Rock","music_genre_vanity":"Rock-Arena-Rock"}}]}}},{"track":{"track_id":108563718,"track_name":"Let
+          It Be (Take 1)","track_name_translation_list":[{"track_name_translation":{"language":"u0","translation":"Let
+          It Be (Take 1)"}}],"track_rating":56,"commontrack_id":59553728,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":0,"num_favourite":1,"album_id":32540708,"album_name":"Anthology
+          3","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Anthology-3-Version?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-Anthology-3-Version\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-04-14T15:37:40Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":21,"music_genre_parent_id":34,"music_genre_name":"Rock","music_genre_name_extended":"Rock","music_genre_vanity":"Rock"}}]}}},{"track":{"track_id":222827361,"track_name":"Let
+          It Be - 1969 Glyn Johns Mix","track_name_translation_list":[],"track_rating":49,"commontrack_id":134402969,"instrumental":0,"explicit":0,"has_lyrics":1,"has_subtitles":1,"has_richsync":0,"num_favourite":0,"album_id":46744542,"album_name":"Let
+          It Be (Super Deluxe)","artist_id":160,"artist_name":"The Beatles","track_share_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-1969-Glyn-Johns-Mix?utm_source=application&utm_campaign=api&utm_medium=","track_edit_url":"https:\/\/www.musixmatch.com\/lyrics\/The-Beatles\/Let-It-Be-1969-Glyn-Johns-Mix\/edit?utm_source=application&utm_campaign=api&utm_medium=","restricted":0,"updated_time":"2024-03-24T18:24:39Z","primary_genres":{"music_genre_list":[{"music_genre":{"music_genre_id":1146,"music_genre_parent_id":21,"music_genre_name":"Arena
+          Rock","music_genre_name_extended":"Rock \/ Arena Rock","music_genre_vanity":"Rock-Arena-Rock"}}]}}}]}}}'
+    recorded_at: Fri, 03 May 2024 17:07:00 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
[MusixMatch](https://www.musixmatch.com) is a service that provides licensing for music lyrics. This is the first pass at integrating with MusixMatch, which hopefully will put ChordBook down a legitimate and legal path. After this is deployed, I'll begin the application process with MusixMatch.

Songsheets that are associated with a known track will now show the MusixMatch copyright notice, along with a link to the track on musixmatch.com, and a tracking image.

<img width="848" alt="image" src="https://github.com/chordbook/chordbook/assets/173/0676a816-152d-45dc-923b-f1cffbdf4e18">
