### PR TITLE
ChordSheetJS to 10.6.2

### DIFF
--- a/client/src/composables/useSongsheetParser.js
+++ b/client/src/composables/useSongsheetParser.js
@@ -83,6 +83,7 @@ export function guessKey(chords) {
   return chords[0]?.root.toString();
 }
 
+// Normalize the key and chords to use the given modifier, and normalize chord suffixes
 export function normalize(song, modifier) {
   let key = Key.parse(song.key)?.useModifier(modifier).normalize();
   return song.setKey(key).mapItems((item) => {
@@ -106,15 +107,7 @@ export function normalize(song, modifier) {
 }
 
 export function getChords(song) {
-  const chords = new Set();
-
-  song?.lines.forEach((line) => {
-    line.items.forEach((pair) => {
-      if (pair.chords) chords.add(pair.chords);
-    });
-  });
-
-  return Array.from(chords)
+  return Array.from(song?.getChords() ?? new Set())
     .map((chord) => Chord.parse(chord))
     .filter(Boolean);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@vueuse/router": "^11.1.0",
         "arrify": "^3.0",
         "autoprefixer": "^10.4.19",
-        "chordsheetjs": "^10.1.0",
+        "chordsheetjs": "^10.6.2",
         "cupertino-pane": "^1.4.21",
         "floating-vue": "^5.2.2",
         "get-youtube-id": "^1.0",
@@ -5133,9 +5133,9 @@
       }
     },
     "node_modules/chordsheetjs": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/chordsheetjs/-/chordsheetjs-10.1.0.tgz",
-      "integrity": "sha512-Ay3g9pLVvfWj2nown6dNo8DAQNc13RzPjigNlfw0nLnEnQxwBy/8tw+5m++dFEuKIZyj8R5Ysrf9MB0JayACYg==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/chordsheetjs/-/chordsheetjs-10.6.2.tgz",
+      "integrity": "sha512-bHlWelM8k+d2Ng/B8CX8r3yQKG5b5IRgJ4FWdsNXdp5DCNJXCTLP7CDPVFmhmJ1iO0909MKah6aoc5mkGuTHRg==",
       "dependencies": {
         "lodash.get": "^4.4.2"
       },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@vueuse/router": "^11.1.0",
     "arrify": "^3.0",
     "autoprefixer": "^10.4.19",
-    "chordsheetjs": "^10.1.0",
+    "chordsheetjs": "^10.6.2",
     "cupertino-pane": "^1.4.21",
     "floating-vue": "^5.2.2",
     "get-youtube-id": "^1.0",


### PR DESCRIPTION
Can't update to 10.7.0 or later due to this bug: https://github.com/martijnversluis/ChordSheetJS/issues/1491