### PR TITLE
Use {define} and {chord} definitions

### DIFF
--- a/client/src/ChordData.js
+++ b/client/src/ChordData.js
@@ -41,7 +41,7 @@ export default class ChordData {
   }
 
   static find(chord, instrument = "guitar", position = 0) {
-    const { key, suffix } = this.translate(chord);
+    const { key, suffix } = this.translate(Chord.parse(chord));
 
     const chordData = this.findChordData(key, instrument);
     const suffixData = chordData?.find((c) => c.suffix === suffix);
@@ -57,6 +57,11 @@ export default class ChordData {
       instruments[instrument].chords[key] ||
       instruments[instrument].chords[keyAliases[key]]
     );
+  }
+
+  // https://martijnversluis.github.io/ChordSheetJS/classes/ChordDefinition.html
+  static fromDefinition(definition) {
+    return new this(definition)
   }
 
   constructor(data) {
@@ -82,7 +87,7 @@ export default class ChordData {
   }
 
   get barres() {
-    return this.data.barres.map((fret) => {
+    return (this.data.barres ?? []).map((fret) => {
       // Get all the strings that could possibly be barred
       const possibleStrings = this.fingerings.filter((f) => f[1] >= fret);
 
@@ -97,6 +102,10 @@ export default class ChordData {
       const toString = strings[strings.length - 1];
       return { fret, fromString, toString };
     });
+  }
+
+  get baseFret() {
+    return this.data.baseFret;
   }
 }
 

--- a/client/src/components/ChordDiagram.vue
+++ b/client/src/components/ChordDiagram.vue
@@ -1,17 +1,17 @@
 <script setup>
-import { Chord } from "chordsheetjs";
+import { ChordDefinition } from "chordsheetjs";
 import ChordData from "@/ChordData";
 import ChordBox from "@/components/ChordBox.vue";
 import { computed } from "vue";
 
 const props = defineProps({
-  as: {
-    type: String,
-    default: "symbol",
-  },
   chord: {
-    type: Chord,
+    type: String,
     required: true,
+  },
+  definition: {
+    type: ChordDefinition,
+    default: null,
   },
   instrument: {
     type: String,
@@ -23,9 +23,13 @@ const props = defineProps({
   },
 });
 
-const data = computed(() =>
-  ChordData.find(props.chord, props.instrument, props.position),
-);
+const data = computed(() => {
+  if(props.definition) {
+    return ChordData.fromDefinition(props.definition);
+  } else {
+    return ChordData.find(props.chord, props.instrument, props.position)
+  }
+});
 </script>
 
 <template>

--- a/client/src/components/ChordDiagramReference.vue
+++ b/client/src/components/ChordDiagramReference.vue
@@ -1,9 +1,7 @@
 <script setup>
-import { Chord } from "chordsheetjs";
-
 defineProps({
   chord: {
-    type: Chord,
+    type: String,
     required: true,
   },
 });
@@ -14,7 +12,7 @@ defineProps({
     class="chord-diagram inline-block"
     xmlns="http://www.w3.org/2000/svg"
     role="image"
-    :title="chord.toString({ useUnicodeModifier: true })"
+    :title="chord"
   >
     <use :xlink:href="`#chord-${chord}`" />
   </svg>

--- a/client/src/components/ChordSheet/Chord.vue
+++ b/client/src/components/ChordSheet/Chord.vue
@@ -11,10 +11,9 @@ const props = defineProps({
   },
 });
 
-const chord = computed(() => Chord.parse(props.name));
-const formatted = computed(
-  () => chord.value?.toString({ useUnicodeModifier: true }) ?? props.name,
-);
+const formatted = computed(() => {
+  return Chord.parse(props.name)?.toString({ useUnicodeModifier: true }) ?? props.name;
+});
 </script>
 
 <template>
@@ -23,10 +22,9 @@ const formatted = computed(
       {{ formatted }}
     </PopoverButton>
     <PopoverPanel
-      v-if="chord"
       class="absolute z-10 -translate-x-1/2 left-1/2 bottom-full mb-1 p-1 pb-0 rounded text-center bg-white dark:bg-slate-900 text-black dark:text-slate-50 border border-solid border-slate-200 dark:border-black/80 shadow-md"
     >
-      <chord-diagram-reference :chord="chord" />
+      <chord-diagram-reference :chord="name" />
     </PopoverPanel>
   </Popover>
 </template>

--- a/client/src/components/KeyModal.vue
+++ b/client/src/components/KeyModal.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { watch, computed, ref, inject } from "vue";
-import { Song, Key } from "chordsheetjs";
-import { getChords, preferredModifierForKey } from "@/composables";
+import { Song, Key, Chord } from "chordsheetjs";
+import { preferredModifierForKey } from "@/composables";
 import MetadataChip from "@/components/MetadataChip.vue";
 
 const props = defineProps({
@@ -36,8 +36,8 @@ const transpositions = computed(() => {
       .useModifier(modifier.value)
       .normalize();
     const chordModifier = modifier.value || preferredModifierForKey(key);
-    const chords = getChords(props.song).map((chord) =>
-      chord.transpose(transpose).useModifier(chordModifier).normalize(key),
+    const chords = props.song?.getChords().map((chord) =>
+      Chord.parse(chord).transpose(transpose).useModifier(chordModifier).normalize(key),
     );
 
     return { step, capo, chords, key };

--- a/client/src/components/Songsheet.vue
+++ b/client/src/components/Songsheet.vue
@@ -2,7 +2,6 @@
 <script setup>
 import AddToLibraryButton from "../components/AddToLibraryButton.vue";
 import AddToSetlistModal from "@/components/AddToSetlistModal.vue";
-import ChordDiagram from "@/components/ChordDiagram.vue";
 import ColumnLayout from "@/components/ColumnLayout.vue";
 import FontSizeControl from "@/components/FontSizeControl.vue";
 import FullscreenButton from "../components/FullscreenButton.vue";
@@ -191,20 +190,16 @@ watch(
     fullscreen
     :class="{ autoscrolling: autoScroll.isActive }"
   >
+    <songsheet-chords-pane
+      ref="chordsPane"
+      slot="fixed"
+      :chords="parser.chords"
+      :definitions="parser.song?.getChordDefinitions()"
+    />
     <column-layout
       :enabled="!parser.error && settings.columns == 2"
       class="relative ion-padding main-content"
     >
-      <!-- Hidden sprite of chord diagrams -->
-      <svg v-if="parser.song" hidden xmlns="http://www.w3.org/2000/svg">
-        <chord-diagram
-          v-for="chord in parser.chords"
-          :key="chord + settings.instrument"
-          :chord="chord"
-          :instrument="settings.instrument"
-        />
-      </svg>
-
       <div v-if="parser.error">
         <h1 class="text-xl md:text-2xl my-1">Error parsing songsheet</h1>
 
@@ -298,11 +293,6 @@ watch(
         </ion-button>
       </div>
     </div>
-    <songsheet-chords-pane
-      ref="chordsPane"
-      slot="fixed"
-      :chords="parser.chords"
-    />
     <Suspense>
       <setlist-songsheets-pager
         v-if="setlistId"

--- a/client/src/components/SongsheetChordsPane.vue
+++ b/client/src/components/SongsheetChordsPane.vue
@@ -1,4 +1,5 @@
 <script setup>
+import ChordDiagram from "@/components/ChordDiagram.vue";
 import InstrumentControl from "@/components/InstrumentControl.vue";
 import ChordDiagramReference from "@/components/ChordDiagramReference.vue";
 import useSongsheetSettings from "@/stores/songsheet-settings";
@@ -6,12 +7,18 @@ import Pane from "@/components/Pane.vue";
 import { ref, defineExpose, computed } from "vue";
 import { useResponsive } from "@/composables";
 
-defineProps({
+const props = defineProps({
   chords: {
     type: Array,
     required: true,
   },
+  definitions: {
+    type: Object,
+    default: null
+  }
 });
+
+const allChords = computed(() => new Set([...props.chords, ...Object.keys(props.definitions || [])]))
 
 defineExpose({
   height: computed(() => chordsModal?.value?.height),
@@ -32,11 +39,21 @@ function onBreakpointDidChange(breakpoint) {
     v-if="sidebar"
     class="left-0 top-0 bottom-0 sidebar bg-white dark:bg-black border-r dark:border-slate-800"
   >
+    <!-- Hidden sprite of chord diagrams -->
+    <svg hidden xmlns="http://www.w3.org/2000/svg">
+      <chord-diagram
+        v-for="chord in allChords"
+        :key="chord + settings.instrument"
+        :chord="chord"
+        :definition="definitions[chord]"
+        :instrument="settings.instrument"
+      />
+    </svg>
     <div
       class="w-[80px] snap-y snap-mandatory flex flex-col overflow-y-auto px-3 h-full"
     >
       <div
-        v-for="chord in chords"
+        v-for="chord in allChords"
         :key="`sidebar-${chord}`"
         class="text-center text-sm snap-start pt-4 first:pt-6 last:pb-6"
       >

--- a/client/src/composables/index.js
+++ b/client/src/composables/index.js
@@ -1,6 +1,5 @@
 export {
   default as useSongsheetParser,
-  getChords,
   preferredModifierForKey,
 } from "./useSongsheetParser";
 export { default as usePaginatedFetch } from "./usePaginatedFetch";

--- a/client/test/ChordData.test.js
+++ b/client/test/ChordData.test.js
@@ -1,9 +1,9 @@
 import ChordData from "@/ChordData";
-import { Chord } from "chordsheetjs";
+import { ChordDefinition } from "chordsheetjs";
 import { describe, expect, test } from "vitest";
 
 test("C", () => {
-  const data = ChordData.find(Chord.parse("C"));
+  const data = ChordData.find("C");
   expect(data.strings).toEqual(6);
   expect(data.fingerings).toEqual([
     [6, "x", null],
@@ -38,10 +38,61 @@ test("C", () => {
       "B",
     ].forEach((chordName) => {
       test(chordName, () => {
-        const chord = Chord.parse(chordName);
-        const data = ChordData.find(chord, instrument);
+        const data = ChordData.find(chordName, instrument);
         expect(data).not.toBeUndefined();
       });
     });
   });
 });
+
+describe('fromDefinition', () => {
+  test('C7', () => {
+    const definition = ChordDefinition.parse('C7 base-fret 1 frets x 3 2 3 1 0')
+    const data = ChordData.fromDefinition(definition)
+
+    expect(data.strings).toEqual(6);
+    expect(data.fingerings).toEqual([
+      [6, "x", null],
+      [5, 3, null],
+      [4, 2, null],
+      [3, 3, null],
+      [2, 1, null],
+      [1, 0, null],
+    ]);
+    expect(data.barres).toEqual([]);
+  });
+
+  test('D7', () => {
+    const definition = ChordDefinition.parse('D7 base-fret 3 frets x 3 2 3 1 x')
+    const data = ChordData.fromDefinition(definition)
+
+    expect(data.strings).toEqual(6);
+    expect(data.baseFret).toEqual(3);
+    expect(data.fingerings).toEqual([
+      [6, "x", null],
+      [5, 3, null],
+      [4, 2, null],
+      [3, 3, null],
+      [2, 1, null],
+      [1, 'x', null],
+    ]);
+    expect(data.barres).toEqual([]);
+  });
+
+  test('E9', () => {
+    const definition = ChordDefinition.parse('E9 base-fret 7 frets 0 1 3 3 0 0')
+    const data = ChordData.fromDefinition(definition)
+
+    expect(data.strings).toEqual(6);
+    expect(data.baseFret).toEqual(7);
+    expect(data.fingerings).toEqual([
+      [6, 0, null],
+      [5, 1, null],
+      [4, 3, null],
+      [3, 3, null],
+      [2, 0, null],
+      [1, 0, null],
+    ]);
+    expect(data.barres).toEqual([]);
+  });
+})

--- a/client/test/composables/useSongsheetParser.test.js
+++ b/client/test/composables/useSongsheetParser.test.js
@@ -1,5 +1,4 @@
 import { useSongsheetParser } from "@/composables";
-import { Chord } from "chordsheetjs";
 import { describe, expect, test, beforeEach } from "vitest";
 import { reactive, nextTick } from "vue";
 
@@ -19,7 +18,7 @@ describe("transposing", () => {
     expect(parser.song.metadata.get("_key")).toEqual("Gm");
     expect(parser.song.key).toEqual("Em");
     expect(parser.song.capo).toEqual("3");
-    expect(parser.chords).toEqual(["Em", "G", "C"].map((c) => Chord.parse(c)));
+    expect(parser.chords).toEqual(["Em", "G", "C"]);
     expect(parser.capo).toEqual(3);
     expect(parser.transpose).toEqual(0);
   });
@@ -32,7 +31,7 @@ describe("transposing", () => {
     expect(parser.song.metadata.get("_key")).toEqual("Gm");
     expect(parser.song.key).toEqual("F#m");
     expect(parser.song.capo).toEqual("1");
-    expect(parser.chords).toEqual(["F#m", "A", "D"].map((c) => Chord.parse(c)));
+    expect(parser.chords).toEqual(["F#m", "A", "D"]);
     expect(parser.transpose).toEqual(0);
   });
 
@@ -69,6 +68,12 @@ describe("transposing", () => {
     expect(parser.song.key).toEqual("C");
     expect(parser.chords.map((c) => c.toString())).toEqual(["C", "G", "D"]);
   });
+
+  test("normalizes chord definitions", async () => {
+    const { song } = reactive(useSongsheetParser("{define: Cmaj7	base-fret 3 frets x 1 3 2 3 1}\n[Cmaj7]"));
+    expect(song.getChords()).toEqual(["Cma7"]);
+    expect(Object.keys(song.getChordDefinitions())).toEqual(["Cma7"]);
+  })
 });
 
 describe("modifier", () => {


### PR DESCRIPTION
[{define}](https://www.chordpro.org/chordpro/directives-define/) and [{chord}](https://www.chordpro.org/chordpro/directives-chord/) directives can be used to define fret/string positions for chord diagrams. This adds support fo using those definitions to render the chord diagrams.
