### PR TITLE
Better chord diagrams

### DIFF
--- a/client/src/components/ChordBox.vue
+++ b/client/src/components/ChordBox.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ChordBox } from "vexchords";
 import ChordData from "@/ChordData";
-import { computed, reactive } from "vue";
+import { computed, ref } from "vue";
 
 const props = defineProps({
   as: {
@@ -22,16 +22,9 @@ const props = defineProps({
   },
 });
 
-// Vexchords adds a lot of padding around the diagram, we'll use viewbox to crop it
-const padding = 0.1;
-const xPadding = computed(() => props.width * padding);
-const yPadding = computed(() => props.width * padding);
-const viewbox = reactive({
-  x: computed(() => xPadding.value + 2), // vexchords seems to draw these slightly shifted right
-  y: yPadding,
-  width: computed(() => props.width - xPadding.value * 2),
-  height: computed(() => props.height - yPadding.value * 2),
-});
+const multiplier = ref(2);
+const width = computed(() => props.width * multiplier.value)
+const height = computed(() => props.height * multiplier.value)
 
 const diagram = computed(() => {
   if (!props.data) return "";
@@ -41,10 +34,12 @@ const diagram = computed(() => {
   new ChordBox(el, {
     numStrings: props.data.strings,
     showTuning: false,
-    width: props.width,
-    height: props.height,
+    width: width.value,
+    height: height.value,
     defaultColor: "currentColor",
     numFrets: 4,
+    fontSize: 10 * multiplier.value,
+    strokeWidth: 0.5 * multiplier.value,
   }).draw({
     // Filter out fingerings for now since they're unreadable anyway
     chord: props.data.fingerings.map((f) => f.slice(0, 2)),
@@ -60,9 +55,7 @@ const diagram = computed(() => {
   <!-- eslint-disable vue/no-v-html vue/no-v-text-v-html-on-component -->
   <component
     :is="as"
-    :width="viewbox.width"
-    :height="viewbox.height"
-    :viewBox="`${viewbox.x} ${viewbox.y} ${viewbox.width} ${viewbox.height}`"
+    :viewBox="`0 0 ${width} ${height}`"
     v-html="diagram"
   />
 </template>

--- a/client/src/components/ChordSheet/Chord.vue
+++ b/client/src/components/ChordSheet/Chord.vue
@@ -17,14 +17,14 @@ const formatted = computed(() => {
 </script>
 
 <template>
-  <Popover class="relative chord">
+  <Popover class="relative chord mr-1" @click.stop>
     <PopoverButton as="span" role="button">
       {{ formatted }}
     </PopoverButton>
     <PopoverPanel
       class="absolute z-10 -translate-x-1/2 left-1/2 bottom-full mb-1 p-1 pb-0 rounded text-center bg-white dark:bg-slate-900 text-black dark:text-slate-50 border border-solid border-slate-200 dark:border-black/80 shadow-md"
     >
-      <chord-diagram-reference :chord="name" />
+      <chord-diagram-reference :chord="name" width="60" height="80" />
     </PopoverPanel>
   </Popover>
 </template>

--- a/client/src/components/SongsheetChordsPane.vue
+++ b/client/src/components/SongsheetChordsPane.vue
@@ -19,6 +19,9 @@ const props = defineProps({
   }
 });
 
+const width = ref(54);
+const height = ref(72);
+
 const allChords = computed(() => new Set([...props.chords, ...Object.keys(props.definitions || [])]))
 
 defineExpose({
@@ -49,19 +52,26 @@ function formattedChord(chord) {
         :chord="chord"
         :definition="definitions[chord]"
         :instrument="settings.instrument"
+        :width="width"
+        :height="height"
       />
     </svg>
     <div
       v-if="sidebar"
-      class="w-[80px] snap-y snap-mandatory flex flex-col overflow-y-auto px-3 h-full"
+      class="w-[80px] snap-y snap-mandatory flex flex-col overflow-y-auto h-full"
     >
       <div
         v-for="chord in allChords"
         :key="`sidebar-${chord}`"
-        class="text-center text-sm snap-start pt-4 first:pt-6 last:pb-6"
+        class="text-center text-sm snap-start first:pt-6 last:pb-6"
       >
-        <div>{{ formattedChord(chord) }}</div>
-        <chord-diagram-reference :chord="chord" />
+        <div><span class="chord block">{{ formattedChord(chord) }}</span></div>
+        <chord-diagram-reference
+          :chord="chord"
+          :width="width"
+          :height="height"
+          class="-mt-2"
+         />
       </div>
     </div>
     <pane
@@ -84,12 +94,17 @@ function formattedChord(chord) {
         <div
           v-for="chord in chords"
           :key="`modal-${chord}`"
-          class="flex flex-col text-center text-sm pointer-events-none select-none snap-start pl-3 first:pl-6 last:pr-6 first:ms-auto last:me-auto"
+          class="flex flex-col text-center text-sm pointer-events-none select-none snap-start first:pl-2 last:pr-2 first:ms-auto last:me-auto"
         >
           <div class="chord">
             {{ formattedChord(chord) }}
           </div>
-          <chord-diagram-reference :chord="chord" />
+          <chord-diagram-reference
+            :chord="chord"
+            :width="width"
+            :height="height"
+            class="-mt-1"
+          />
         </div>
       </div>
       <ion-footer>

--- a/client/src/components/SongsheetContent.vue
+++ b/client/src/components/SongsheetContent.vue
@@ -124,7 +124,7 @@ const theme = useThemeStore();
 }
 
 .chord {
-  @apply text-indigo-800 dark:text-indigo-500 font-semibold mr-1;
+  @apply text-indigo-800 dark:text-indigo-500 font-semibold;
 }
 
 .annotation,
@@ -164,11 +164,6 @@ const theme = useThemeStore();
 .chord:after,
 .lyrics:after {
   content: "\200b";
-}
-
-.chord-diagram {
-  width: 40px;
-  height: 52px;
 }
 
 .themed[data-font-size="sm"] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "string-hash": "^1.1",
         "tailwindcss": "^3.4.16",
         "tinycolor2": "^1.6.0",
-        "vexchords": "^1.2",
+        "vexchords": "github:chordbook/vexchords",
         "vite": "^6.0.3",
         "vite-plugin-pwa": "^0.21.1",
         "vite-svg-loader": "^5.1.0",
@@ -3445,9 +3445,9 @@
       }
     },
     "node_modules/@svgdotjs/svg.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.0.tgz",
-      "integrity": "sha512-Tr8p+QVP7y+QT1GBlq1Tt57IvedVH8zCPoYxdHLX0Oof3a/PqnC/tXAkVufv1JQJfsDHlH/UrjcDfgxSofqSNA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.4.tgz",
+      "integrity": "sha512-BjJ/7vWNowlX3Z8O4ywT58DqbNRyYlkk6Yz/D13aB7hGmfQTvGX4Tkgtm/ApYlu9M7lCQi15xUEidqMUmdMYwg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Fuzzyma"
@@ -10572,10 +10572,10 @@
     },
     "node_modules/vexchords": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vexchords/-/vexchords-1.2.0.tgz",
-      "integrity": "sha512-ObhyFjGiN4pj+oFBGmCa9/geY6H6xqbEipTp1k8de7UXjvv30CriHjD8FR3Lf3jo1vSVUCePSJd7024qmJyNlA==",
+      "resolved": "git+ssh://git@github.com/chordbook/vexchords.git#c41d8a1e1680a7f5e845d64cc1803a255b5588e1",
+      "license": "MIT",
       "dependencies": {
-        "@svgdotjs/svg.js": "^3.0.12"
+        "@svgdotjs/svg.js": "^3.2.4"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "string-hash": "^1.1",
     "tailwindcss": "^3.4.16",
     "tinycolor2": "^1.6.0",
-    "vexchords": "^1.2",
+    "vexchords": "github:chordbook/vexchords",
     "vite": "^6.0.3",
     "vite-plugin-pwa": "^0.21.1",
     "vite-svg-loader": "^5.1.0",


### PR DESCRIPTION
Improves chord rendering with these improvments:

1. https://github.com/0xfe/vexchords/pull/49
2. https://github.com/0xfe/vexchords/pull/50
3. https://github.com/0xfe/vexchords/pull/52



<table>
  <tr>
  <th>Before</th>
  <th>After</th>
  </tr>
  <tr>
  <td><img width="80" alt="image" src="https://github.com/user-attachments/assets/a11d3eab-9fd3-43e6-94ef-38b3df3d467a" /></td>
  <td><img width="79" alt="image" src="https://github.com/user-attachments/assets/891f23f3-ff71-4560-92fa-74364adad5fa" /></td>
  </tr>
</table>